### PR TITLE
Add install.sh to symlink configs to their expected locations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTFILES="$(cd "$(dirname "$0")" && pwd)"
+
+link() {
+  local src="$DOTFILES/$1" dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  ln -sf "$src" "$dst"
+  echo "linked $dst -> $src"
+}
+
+link zsh/.zshrc                  "$HOME/.zshrc"
+link starship/starship.toml      "$HOME/.config/starship/starship.toml"
+link wezterm/wezterm.lua         "$HOME/.config/wezterm/wezterm.lua"


### PR DESCRIPTION
Adds `install.sh` to make the repo the source of truth for local machine configuration. The script symlinks `~/.zshrc`, `~/.config/starship/starship.toml`, and `~/.config/wezterm/wezterm.lua` to their counterparts in the repo. The repo root is resolved dynamically from the script's location, so it works regardless of where the repo is cloned.