### PR TITLE
Fix zsh plugin paths for Apple Silicon

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -18,8 +18,8 @@ export STARSHIP_CONFIG=~/.config/starship/starship.toml
 eval "$(starship init zsh)"
 
 ## zsh
-source /usr/local/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 ZSH_THEME="dracula"
 (( ${+ZSH_HIGHLIGHT_STYLES} )) || typeset -A ZSH_HIGHLIGHT_STYLES


### PR DESCRIPTION
## Summary
- Updates `zsh-syntax-highlighting` and `zsh-autosuggestions` source paths from `/usr/local/share/` to `/opt/homebrew/share/`

`/usr/local` is the Homebrew prefix on Intel Macs; Apple Silicon Macs use `/opt/homebrew`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)