### PR TITLE
Suppress zoxide doctor false positive warning

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -142,6 +142,7 @@ export FZF_DEFAULT_OPTS='--color=fg:#f8f8f2,bg:#282a36,hl:#bd93f9 --color=fg+:#f
 alias ls="eza --color=always --git --icons=always --hyperlink --tree --level=1 --group-directories-first --ignore-glob=__pycache__"
 
 ## zoxide
+export _ZO_DOCTOR=0
 eval "$(zoxide init zsh --cmd cd)"
 
 ## lazy*


### PR DESCRIPTION
Sets `_ZO_DOCTOR=0` to suppress the zoxide configuration warning that fires on every shell startup. The warning is a false positive caused by `fnm --use-on-cd` registering a `chpwd` hook alongside zoxide's `--cmd cd` wrapper — both tools work correctly together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)