### PR TITLE
Add otto alias for astro otto command

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -67,6 +67,7 @@ alias awks="astro workspace switch"
 alias adl="astro deployment list"
 
 alias adup="astro dev upgrade-test $@"
+alias otto="astro otto"
 
 ## Git
 alias g="git"


### PR DESCRIPTION
## Summary
Adds a convenient `otto` alias for the `astro otto` CLI command, allowing users to run `otto` instead of the full command name.