### PR TITLE
Source ~/.zshrc.local for machine-specific shell config

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -149,3 +149,6 @@ eval "$(zoxide init zsh --cmd cd)"
 ## lazy*
 alias lzg="lazygit"
 alias lzd="lazydocker"
+
+## Local overrides
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local


### PR DESCRIPTION
Adds a hook at the bottom of `.zshrc` to source `~/.zshrc.local` if it exists, allowing machine-specific config (e.g. gcloud CLI path setup) to live outside the repo. The `.zshrc.local` file is created directly on the local machine and is never committed.